### PR TITLE
Improved pattern

### DIFF
--- a/pterodactyl-sftp.conf
+++ b/pterodactyl-sftp.conf
@@ -12,8 +12,9 @@ before = common.conf
 [Definition]
 
 _daemon = wings
+journalmatch = _SYSTEMD_UNIT=%(_daemon)s.service
 
-failregex = ^ WARN: .* failed to validate user credentials \(invalid format\) ip=<HOST>:.* subsystem=sftp username=.*$
+failregex = failed to validate user credentials \([^\)]+\) ip=<HOST>:.* subsystem=sftp username=.*$
 
 ignoreregex =
 


### PR DESCRIPTION
Setting the daemon to wings improves matching performance and not forcing the start of the log message allows for more reliable matches (the previous regex never matched for me when using systemd as a log source.